### PR TITLE
Fix a potential NULL pointer dereference and set ioctl errno codes

### DIFF
--- a/module/src/global_state.c
+++ b/module/src/global_state.c
@@ -79,7 +79,7 @@ PageId alloc_new_page(struct global_state *state)
 
 void inc_usage(struct global_state *state, PageId pageId)
 {
-	if (pageId > state->page_info_size) {
+	if (pageId >= state->page_info_size) {
 		//check for page id to be in range
 		printk(KERN_ALERT "REWIRING_LKM: invalid pageId:%u\n", pageId);
 		return;

--- a/module/src/rewiring-lkm.c
+++ b/module/src/rewiring-lkm.c
@@ -307,6 +307,10 @@ static long handle_command(struct file *file, struct cmd *command)
         }
 		copy_from_user(newPageIds, command->payload,
 			       command->len * sizeof(PageId));
+		//check if any of the new PageIds is out-of-range
+		for (unsigned long i = 0; i < command->len; i++)
+			if (newPageIds[i] >= state->global->page_info_size)
+				return -EINVAL;
 		//process data
 		for (unsigned long i = 0; i < command->len; i++) {
 			set_page_id(state, command->start + i, newPageIds[i]);


### PR DESCRIPTION
The PR fixes two problems: `inc_usage` had an off-by-one error in its range check and `SET_PAGE_IDS` didn't check the PageId range at all.

`handle_command` also should now also return the proper error messages instead of just `EPERM`